### PR TITLE
90%: Fix Compose file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
-    "name": "twbs/bootstrap-sass",
+    "name": "talis/bootstrap-sass",
     "description": "bootstrap-sass is a Sass-powered version of Bootstrap 3, ready to drop right into your Sass powered applications.",
     "keywords": ["bootstrap", "css", "sass"],
-    "homepage": "http://github.com/twbs/bootstrap-sass",
+    "homepage": "http://github.com/talis/bootstrap-sass",
     "authors": [
         {
             "name": "Thomas McDonald"
@@ -24,7 +24,7 @@
         }
     ],
     "support": {
-        "issues": "https://github.com/twbs/bootstrap-sass/issues"
+        "issues": "https://github.com/talis/bootstrap-sass/issues"
     },
     "license": "MIT",
     "extra": {


### PR DESCRIPTION
So that PHP projects can use this. Fixes the following composer error:

```
[InvalidArgumentException]                                                                                                                            
  Could not find package talis/bootstrap-sass at any version for your minimum-stability (stable). Check the package spelling or your minimum-stability
```

Usage in dependent projects:

```json
"talis/bootstrap-sass": "dev-master#v3.3.8-talis"
```