### PR TITLE
Add table bottom border from atlas ux review

### DIFF
--- a/assets/stylesheets/bootstrap/_tables.scss
+++ b/assets/stylesheets/bootstrap/_tables.scss
@@ -25,6 +25,7 @@ th {
   width: 100%;
   max-width: 100%;
   margin-bottom: $line-height-computed;
+  border-bottom: 1px solid $misty;
   // Cells
   > thead,
   > tbody,


### PR DESCRIPTION
Implements a bottom border for tables, per Atlas UX review:

![core_textbook_preferences](https://cloud.githubusercontent.com/assets/72548/19943606/820fdc90-a10e-11e6-882a-597fc4ff4555.png)
