### PR TITLE
Use semver range

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -31,7 +31,7 @@
     "docs"
   ],
   "dependencies": {
-    "jquery": ">=1.9.1 <3"
+    "jquery": "~1.9.1"
   },
   "version": "3.3.6-talis.10"
 }

--- a/bower.json
+++ b/bower.json
@@ -31,7 +31,7 @@
     "docs"
   ],
   "dependencies": {
-    "jquery": "1.9.1 - 2"
+    "jquery": ">=1.9.1 <3"
   },
   "version": "3.3.6-talis.10"
 }


### PR DESCRIPTION
Installing through bower pulls jquery 3.x, which is incompatible with Bootstrap 3.

It doesn't appear as though `ver1 - ver2` is valid syntax.