### PR TITLE
PLAT-568 Fix table overflow issue.

### DIFF
--- a/assets/stylesheets/bootstrap/_tables.scss
+++ b/assets/stylesheets/bootstrap/_tables.scss
@@ -172,7 +172,7 @@ table {
 // will display normally.
 
 .table-responsive {
-  overflow-x: auto;
+  overflow: inherit;
   min-height: 0.01%; // Workaround for IE9 bug (see https://github.com/twbs/bootstrap/issues/14837)
 
   @media screen and (max-width: $screen-xs-max) {


### PR DESCRIPTION
Atlas is seeing a problem with dropdown menus in tables causing scrollbars to appear and the menu then being clipped.

![problem](https://cloud.githubusercontent.com/assets/232529/22289481/b1affd32-e2f3-11e6-8f89-9fccb9a52ac4.png)

![problem_2](https://cloud.githubusercontent.com/assets/232529/22289569/375e2468-e2f4-11e6-83fb-87b40419c74b.png)

This PR attempts to fix the problem by changing the overflow on table-responsive as shown below.

![fix](https://cloud.githubusercontent.com/assets/232529/22289583/46959236-e2f4-11e6-8f6f-e7ff89598cb9.png)

I did wonder if this will break the responsiveness of the table. This does not seem to be the case. The following two screenshots show the table resized for both a tablet and a phone before the change.

![tablet_before](https://cloud.githubusercontent.com/assets/232529/22289716/01b610a4-e2f5-11e6-97dc-622ddb84ba98.png)

![phone_before](https://cloud.githubusercontent.com/assets/232529/22289721/089ff31c-e2f5-11e6-9dc4-75705d103e65.png)

The following two screenshots show the tables resized for a tablet and a phone with this change applied.

![tablet_after](https://cloud.githubusercontent.com/assets/232529/22289759/2693c52e-e2f5-11e6-86f9-9e50ca193020.png)

![phone_after](https://cloud.githubusercontent.com/assets/232529/22289770/2f99e36a-e2f5-11e6-9647-4f5a89d9a4c9.png)

The change is fixing the problem when the screen is resized for a tablet.

The phone view is not changed by this PR - you can still scroll left to right. But the table isn't looking great before or after.






