### PR TITLE
Update onboarding example with accessability extras

### DIFF
--- a/index.html
+++ b/index.html
@@ -780,7 +780,7 @@
       <div class="col-xs-12">
         <h2>Onboarding Tips</h2>
 
-        <aside class="c-tip c-tip--onboarding" aria-labelledby="tipTitle tipContent" tabindex="0">
+        <aside class="c-tip c-tip--onboarding" aria-describedby="tipTitle tipContent" tabindex="0">
           <i class="c-tip__icon far fa-lightbulb" role="presentation"></i>
           <div class="c-tip__text">
             <strong class="c-tip__title" id="tipTitle">Title</strong>

--- a/index.html
+++ b/index.html
@@ -780,11 +780,11 @@
       <div class="col-xs-12">
         <h2>Onboarding Tips</h2>
 
-        <aside class="c-tip c-tip--onboarding" aria-labelledby="tipTitle">
+        <aside class="c-tip c-tip--onboarding" aria-labelledby="tipTitle tipContent" tabindex="0">
           <i class="c-tip__icon far fa-lightbulb" role="presentation"></i>
           <div class="c-tip__text">
             <strong class="c-tip__title" id="tipTitle">Title</strong>
-            <p class="c-tip__content">Tip text goes here…</p>
+            <p class="c-tip__content" id="tipContent">Tip text goes here…</p>
           </div>
         </aside>
       </div>


### PR DESCRIPTION
Following on from #56, update the onboarding tip example to ensure both tip title and content are read out by screen readers. Also adds a tab index so that a user can focus it on order for the screen reader to engage.