### PR TITLE
Allow use of buttons in dropdowns

### DIFF
--- a/assets/stylesheets/bootstrap/_dropdowns.scss
+++ b/assets/stylesheets/bootstrap/_dropdowns.scss
@@ -75,7 +75,7 @@
   > li > button {
     touch-action: manipulation;
     width: 100%;
-    padding: 2px 11px;
+    padding: 2px 20px;
     font-weight: normal;
     text-align: left;
     color: $dropdown-link-color;

--- a/assets/stylesheets/bootstrap/_dropdowns.scss
+++ b/assets/stylesheets/bootstrap/_dropdowns.scss
@@ -71,10 +71,25 @@
     color: $dropdown-link-color;
     white-space: nowrap; // prevent links from randomly breaking onto new lines
   }
+
+  > li > button {
+    touch-action: manipulation;
+    width: 100%;
+    padding: 2px 11px;
+    font-weight: normal;
+    text-align: left;
+    color: $dropdown-link-color;
+    white-space: nowrap; // prevent links from randomly breaking onto new lines
+    background-color: transparent;
+    background-image: none; // Reset unusual Firefox-on-Android default style; see https://github.com/necolas/normalize.css/issues/214
+    border: 1px solid transparent;
+    @include user-select(none);
+  }
 }
 
 // Hover/Focus state
-.dropdown-menu > li > a {
+.dropdown-menu > li > a,
+.dropdown-menu > li > button {
   &:hover,
   &:focus {
     text-decoration: none;
@@ -84,7 +99,8 @@
 }
 
 // Active state
-.dropdown-menu > .active > a {
+.dropdown-menu > .active > a,
+.dropdown-menu > .active > button {
   &,
   &:hover,
   &:focus {
@@ -99,7 +115,8 @@
 //
 // Gray out text and ensure the hover/focus state remains gray
 
-.dropdown-menu > .disabled > a {
+.dropdown-menu > .disabled > a,
+.dropdown-menu > .disabled > button {
   &,
   &:hover,
   &:focus {
@@ -119,7 +136,8 @@
 
 // Danger (!) state
 // List item appears in red and darkens on hover/focus
-.dropdown-menu > .danger > a {
+.dropdown-menu > .danger > a,
+.dropdown-menu > .danger > button {
   color: $red;
   &:hover,
   &:focus {
@@ -141,7 +159,8 @@
   }
 
   // Remove the outline when :focus is triggered
-  > a {
+  > a,
+  > button {
     outline: 0;
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -33,5 +33,5 @@
   "dependencies": {
     "jquery": "~1.9.1"
   },
-  "version": "3.3.6-talis.21"
+  "version": "3.3.6-talis.22"
 }

--- a/dist/app.min.css
+++ b/dist/app.min.css
@@ -2458,7 +2458,7 @@ tbody.collapse.in {
   .dropdown-menu > li > button {
     touch-action: manipulation;
     width: 100%;
-    padding: 2px 11px;
+    padding: 2px 20px;
     font-weight: normal;
     text-align: left;
     color: #017d87;

--- a/dist/app.min.css
+++ b/dist/app.min.css
@@ -2455,41 +2455,72 @@ tbody.collapse.in {
     line-height: 1.6;
     color: #017d87;
     white-space: nowrap; }
+  .dropdown-menu > li > button {
+    touch-action: manipulation;
+    width: 100%;
+    padding: 2px 11px;
+    font-weight: normal;
+    text-align: left;
+    color: #017d87;
+    white-space: nowrap;
+    background-color: transparent;
+    background-image: none;
+    border: 1px solid transparent;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none; }
 
-.dropdown-menu > li > a:hover, .dropdown-menu > li > a:focus {
+.dropdown-menu > li > a:hover, .dropdown-menu > li > a:focus,
+.dropdown-menu > li > button:hover,
+.dropdown-menu > li > button:focus {
   text-decoration: none;
   color: #fff;
   background-color: #005d64; }
 
-.dropdown-menu > .active > a, .dropdown-menu > .active > a:hover, .dropdown-menu > .active > a:focus {
+.dropdown-menu > .active > a, .dropdown-menu > .active > a:hover, .dropdown-menu > .active > a:focus,
+.dropdown-menu > .active > button,
+.dropdown-menu > .active > button:hover,
+.dropdown-menu > .active > button:focus {
   color: #fff;
   text-decoration: none;
   outline: 0;
   background-color: #005d64; }
 
-.dropdown-menu > .disabled > a, .dropdown-menu > .disabled > a:hover, .dropdown-menu > .disabled > a:focus {
+.dropdown-menu > .disabled > a, .dropdown-menu > .disabled > a:hover, .dropdown-menu > .disabled > a:focus,
+.dropdown-menu > .disabled > button,
+.dropdown-menu > .disabled > button:hover,
+.dropdown-menu > .disabled > button:focus {
   color: #495057; }
 
-.dropdown-menu > .disabled > a:hover, .dropdown-menu > .disabled > a:focus {
+.dropdown-menu > .disabled > a:hover, .dropdown-menu > .disabled > a:focus,
+.dropdown-menu > .disabled > button:hover,
+.dropdown-menu > .disabled > button:focus {
   text-decoration: none;
   background-color: transparent;
   background-image: none;
   filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);
   cursor: not-allowed; }
 
-.dropdown-menu > .danger > a {
+.dropdown-menu > .danger > a,
+.dropdown-menu > .danger > button {
   color: #a02f2b; }
-  .dropdown-menu > .danger > a:hover, .dropdown-menu > .danger > a:focus {
+  .dropdown-menu > .danger > a:hover, .dropdown-menu > .danger > a:focus,
+  .dropdown-menu > .danger > button:hover,
+  .dropdown-menu > .danger > button:focus {
     color: #ffffff; }
-  .dropdown-menu > .danger > a:hover {
+  .dropdown-menu > .danger > a:hover,
+  .dropdown-menu > .danger > button:hover {
     background-color: #a02f2b; }
-  .dropdown-menu > .danger > a:focus {
+  .dropdown-menu > .danger > a:focus,
+  .dropdown-menu > .danger > button:focus {
     background-color: #852522; }
 
 .open > .dropdown-menu {
   display: block; }
 
-.open > a {
+.open > a,
+.open > button {
   outline: 0; }
 
 .dropdown-menu-right {

--- a/index.html
+++ b/index.html
@@ -225,7 +225,29 @@
               <li class="divider"></li>
               <li class="danger">
                 <a href="#">Delete</a>
-              </li </ul>
+              </li>
+            </ul>
+          </div>
+
+          <div class="btn-group">
+            <button class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+              Button dropdown
+              <span class="caret"></span>
+            </button>
+            <ul class="dropdown-menu">
+              <li>
+                <button>Button 1</button>
+              </li>
+              <li class="active">
+                <button>Button active</button>
+              </li>
+              <li class="disabled">
+                <button disabled>Button disabled</button>
+              </li>
+              <li class="danger">
+                <button>Button delete</button>
+              </li>
+            </ul>
           </div>
 
           <hr>
@@ -251,9 +273,9 @@
               <li class="divider"></li>
               <li class="danger">
                 <a href="#">Delete</a>
-              </li </ul>
+              </li>
+            </ul>
           </div>
-
 
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -229,27 +229,6 @@
             </ul>
           </div>
 
-          <div class="btn-group">
-            <button class="btn btn-default dropdown-toggle" data-toggle="dropdown">
-              Button dropdown
-              <span class="caret"></span>
-            </button>
-            <ul class="dropdown-menu">
-              <li>
-                <button>Button 1</button>
-              </li>
-              <li class="active">
-                <button>Button active</button>
-              </li>
-              <li class="disabled">
-                <button disabled>Button disabled</button>
-              </li>
-              <li class="danger">
-                <button>Button delete</button>
-              </li>
-            </ul>
-          </div>
-
           <hr>
 
           <div class="btn-group">
@@ -610,7 +589,33 @@
             <li class="divider"></li>
             <li class="danger">
               <a href="#">Delete</a>
-            </li </ul>
+            </li>
+          </ul>
+        </div>
+
+        <div class="btn-group">
+          <button class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+            Button dropdown
+            <span class="caret"></span>
+          </button>
+          <ul class="dropdown-menu">
+            <li class="dropdown-header">Dropdown header</li>
+            <li>
+              <button>Button 1</button>
+            </li>
+            <li class="active">
+              <button>Button active</button>
+            </li>
+            <li class="divider"></li>
+            <li class="dropdown-header">Dropdown header</li>
+            <li class="disabled">
+              <button disabled>Button disabled</button>
+            </li>
+            <li class="divider"></li>
+            <li class="danger">
+              <button>Button delete</button>
+            </li>
+          </ul>
         </div>
       </div>
     </section>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bootstrap-sass",
-  "version": "3.3.6-talis.21",
+  "version": "3.3.6-talis.22",
   "description": "bootstrap-sass is a Sass-powered version of Bootstrap 3, ready to drop right into your Sass powered applications.",
   "main": "assets/javascripts/bootstrap.js",
   "style": "assets/stylesheets/_bootstrap.scss",


### PR DESCRIPTION
Style the buttons so that they look and act exactly the same as their anchor counterparts.

See talis/shipshape-app#1319 for more details.

![dropdowns](https://user-images.githubusercontent.com/557957/42882821-ac640656-8a91-11e8-885f-b536afed7c52.png)

Tested on (latest):

- [x] Chrome (inc Android)
- [x] Firefox
- [x] Safari (inc iOS)
- [x] Opera
- [x] Edge
- [x] IE