### PR TITLE
Remove white color from `.btn-alert:hover:focus` state

### DIFF
--- a/assets/stylesheets/bootstrap/mixins/_buttons.scss
+++ b/assets/stylesheets/bootstrap/mixins/_buttons.scss
@@ -259,7 +259,7 @@
   }
 
   &:hover:active {
-    background-color: #gray800;
+    background-color: $gray800;
     color: $white;
   }
 

--- a/assets/stylesheets/bootstrap/mixins/_buttons.scss
+++ b/assets/stylesheets/bootstrap/mixins/_buttons.scss
@@ -168,10 +168,6 @@
       0px 0px 0px 2px transparent,
   }
 
-  &:hover:focus {
-    color: $white;
-  }
-
   &:active,
   &.active,
   .open > &.dropdown-toggle {


### PR DESCRIPTION
#### Problem
When a button with the `btn-alert` class applied is focussed and hovered at the same time, the text turns white, which is not readable

#### Example
The third button in this screenshot is hovered and focussed
![image](https://user-images.githubusercontent.com/5774647/96126094-ed85bb80-0eeb-11eb-9579-2b36a7818994.png)

#### Fix
Remove the white color from `.btn-alert:hover:focus` state